### PR TITLE
Adding support for promises to all API methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ elemeno.getCollectionItems('recipes', function(err, response) {
 	// Do something with the response
 	console.log(response);
 });
+
+// All methods can also return promises:
+elemeno.getCollectionItems('recipes').then(function(response) {
+		// Do something with the response
+	}, function(error) {
+		// Handle the error
+	});
+
 ```
 
 ## Caching
@@ -58,7 +66,7 @@ var elemeno = new Elemeno('123e4567-e89b-12d3-a456-426655440000', options);
 
 ### Singles
 
-#### getSingles([options,] cb)
+#### getSingles([options,] [cb])
 
 ```js
 elemeno.getSingles(
@@ -78,7 +86,7 @@ elemeno.getSingles(
 );
 ```
 
-#### getSingle(singleSlug, cb)
+#### getSingle(singleSlug, [cb])
 
 ```js
 elemeno.getSingle(
@@ -94,7 +102,7 @@ elemeno.getSingle(
 
 ### Collections
 
-#### getCollections([options,] cb)
+#### getCollections([options,] [cb])
 
 ```js
 elemeno.getCollections(
@@ -114,7 +122,7 @@ elemeno.getCollections(
 );
 ```
 
-#### getCollection(collectionSlug, cb)
+#### getCollection(collectionSlug, [cb])
 
 ```js
 elemeno.getCollection(
@@ -128,7 +136,7 @@ elemeno.getCollection(
 );
 ```
 
-#### getCollectionItems(collectionSlug, [options,] cb)
+#### getCollectionItems(collectionSlug, [options,] [cb])
 
 ```js
 elemeno.getCollectionItems(
@@ -154,7 +162,7 @@ elemeno.getCollectionItems(
 );
 ```
 
-#### getCollectionItem(collectionSlug, itemSlug, [options,] cb)
+#### getCollectionItem(collectionSlug, itemSlug, [options,] [cb])
 
 ```js
 elemeno.getCollectionItem(

--- a/lib/elemeno.js
+++ b/lib/elemeno.js
@@ -2,6 +2,7 @@
 
 const crypto = require('crypto');
 const LRU = require('lru-cache');
+const Promise = require('promise');
 const request = require('superagent');
 const sizeof = require('object-sizeof')
 
@@ -56,12 +57,7 @@ class Elemeno {
 		return query;
 	}
 
-	get(path, query, cb) {
-		if (typeof cb === 'undefined') {
-			cb = query;
-			query = null;
-		}
-
+	get(path, query) {
 		let self = this;
 		let cacheKey;
 
@@ -76,23 +72,25 @@ class Elemeno {
 			}
 		}
 
-		let req = request.get(this.baseUrl + path);
-		req.set('Authorization', this.apiKey);
+		return new Promise((resolve, reject) => {
+			let req = request.get(this.baseUrl + path);
+			req.set('Authorization', this.apiKey);
 
-		if (query) {
-			req.query(query)
-		}
-
-		req.end(function(err, res) {
-			if (err) {
-				return cb(err.response.error);
+			if (query) {
+				req.query(query)
 			}
 
-			if (self.cache) {
-				self.cache.set(cacheKey, res.body);
-			}
+			req.end(function(err, res) {
+				if (err) {
+					reject(err.response.error);
+				}
 
-			cb(null, res.body);
+				if (self.cache) {
+					self.cache.set(cacheKey, res.body);
+				}
+
+				resolve(res.body)
+			});
 		});
 	}
 
@@ -105,13 +103,13 @@ class Elemeno {
 		let path = this.singleBase;
 		let query = Elemeno.getQuery(options, ['sort']);
 
-		return this.get(path, query, cb);
+		return this.get(path, query).nodeify(cb);
 	}
 
 	getSingle(singleSlug, cb) {
 		let path = this.singleBase + singleSlug;
 
-		return this.get(path, cb);
+		return this.get(path).nodeify(cb);
 	}
 
 	getCollections(options, cb) {
@@ -123,13 +121,13 @@ class Elemeno {
 		let path = this.collectionBase;
 		let query = Elemeno.getQuery(options, ['sort']);
 
-		return this.get(path, query, cb);
+		return this.get(path, query).nodeify(cb);
 	}
 
 	getCollection(collectionSlug, cb) {
 		let path = this.collectionBase + collectionSlug;
 
-		return this.get(path, cb);
+		return this.get(path).nodeify(cb);
 	}
 
 	getCollectionItems(collectionSlug, options, cb) {
@@ -141,7 +139,7 @@ class Elemeno {
 		let path = this.collectionBase + collectionSlug + '/items/';
 		let query = Elemeno.getQuery(options, ['filters', 'sort']);
 
-		return this.get(path, query, cb);
+		return this.get(path, query).nodeify(cb);
 	}
 
 	getCollectionItem(collectionSlug, itemSlug, options, cb) {
@@ -153,7 +151,7 @@ class Elemeno {
 		let path = this.collectionBase + collectionSlug + '/items/' + itemSlug;
 		let query = Elemeno.getQuery(options);
 
-		return this.get(path, query, cb);
+		return this.get(path, query).nodeify(cb);
 	}
 
 	clearCache() {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "lru-cache": "~4.0.2",
     "object-sizeof": "~1.1.1",
+    "promise": "^7.1.1",
     "superagent": "~2.0.0"
   },
   "engines": {


### PR DESCRIPTION
Support is added in a backwards compatible manner. If a callback is
defined, it is returned. Otherwise the API methods will return promises.